### PR TITLE
Touch up the driver code in a couple of places

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -80,6 +80,7 @@ func BenchmarkQuery(b *testing.B) {
 	var wg sync.WaitGroup
 	wg.Add(concurrencyLevel)
 	defer wg.Wait()
+	b.ResetTimer()
 	b.StartTimer()
 
 	for i := 0; i < concurrencyLevel; i++ {
@@ -117,6 +118,7 @@ func BenchmarkExec(b *testing.B) {
 	var wg sync.WaitGroup
 	wg.Add(concurrencyLevel)
 	defer wg.Wait()
+	b.ResetTimer()
 	b.StartTimer()
 
 	for i := 0; i < concurrencyLevel; i++ {
@@ -232,8 +234,9 @@ func BenchmarkInterpolation(b *testing.B) {
 		time.Unix(1423411542, 807015000),
 		[]byte("bytes containing special chars ' \" \a \x00"),
 		"string containing special chars ' \" \a \x00",
+		uint64(math.MaxUint64),
 	}
-	q := "SELECT ?, ?, ?, ?, ?, ?"
+	q := "SELECT ?, ?, ?, ?, ?, ?, ?"
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/connection.go
+++ b/connection.go
@@ -268,6 +268,8 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 				buf = escapeStringQuotes(buf, v)
 			}
 			buf = append(buf, '\'')
+		case uint64:
+			buf = strconv.AppendUint(buf, v, 10)
 		default:
 			return "", driver.ErrSkip
 		}

--- a/statement.go
+++ b/statement.go
@@ -12,6 +12,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"reflect"
+	"strconv"
 )
 
 type mysqlStmt struct {
@@ -139,7 +140,7 @@ func (converter) ConvertValue(v interface{}) (driver.Value, error) {
 	case reflect.Uint64:
 		u64 := rv.Uint()
 		if u64 >= 1<<63 {
-			return fmt.Sprintf("%d", u64), nil
+			return strconv.FormatUint(u64, 10), nil
 		}
 		return int64(u64), nil
 	case reflect.Float32, reflect.Float64:


### PR DESCRIPTION
Switches an Sprint for the faster strconv call, and add support for
uint64 vals in the interpolation code