### PR TITLE
More touchups

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -234,7 +234,7 @@ func BenchmarkInterpolation(b *testing.B) {
 		time.Unix(1423411542, 807015000),
 		[]byte("bytes containing special chars ' \" \a \x00"),
 		"string containing special chars ' \" \a \x00",
-		uint64(math.MaxUint64),
+		uint64(1<<63 - 1),
 	}
 	q := "SELECT ?, ?, ?, ?, ?, ?, ?"
 

--- a/connection.go
+++ b/connection.go
@@ -269,6 +269,9 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 			}
 			buf = append(buf, '\'')
 		case uint64:
+			if v >= 1<<63 {
+				return "", driver.ErrSkip
+			}
 			buf = strconv.AppendUint(buf, v, 10)
 		default:
 			return "", driver.ErrSkip

--- a/connection.go
+++ b/connection.go
@@ -193,8 +193,31 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 		}
 
 		switch v := arg.(type) {
+		case int8:
+			buf = strconv.AppendInt(buf, int64(v), 10)
+		case int16:
+			buf = strconv.AppendInt(buf, int64(v), 10)
+		case int32:
+			buf = strconv.AppendInt(buf, int64(v), 10)
+		case int:
+			buf = strconv.AppendInt(buf, int64(v), 10)
 		case int64:
 			buf = strconv.AppendInt(buf, v, 10)
+		case uint8:
+			buf = strconv.AppendUint(buf, uint64(v), 10)
+		case uint16:
+			buf = strconv.AppendUint(buf, uint64(v), 10)
+		case uint32:
+			buf = strconv.AppendUint(buf, uint64(v), 10)
+		case uint:
+			buf = strconv.AppendUint(buf, uint64(v), 10)
+		case uint64:
+			if v >= 1<<63 {
+				return "", driver.ErrSkip
+			}
+			buf = strconv.AppendUint(buf, v, 10)
+		case float32:
+			buf = strconv.AppendFloat(buf, float64(v), 'g', -1, 32)
 		case float64:
 			buf = strconv.AppendFloat(buf, v, 'g', -1, 64)
 		case bool:
@@ -268,11 +291,6 @@ func (mc *mysqlConn) interpolateParams(query string, args []driver.Value) (strin
 				buf = escapeStringQuotes(buf, v)
 			}
 			buf = append(buf, '\'')
-		case uint64:
-			if v >= 1<<63 {
-				return "", driver.ErrSkip
-			}
-			buf = strconv.AppendUint(buf, v, 10)
 		default:
 			return "", driver.ErrSkip
 		}


### PR DESCRIPTION
the driver can only support uint64 args with the high bit set in a
prepared statement, so we should return err if we see one